### PR TITLE
v0 preliminary scripts for equity calculation

### DIFF
--- a/devpie/README.md
+++ b/devpie/README.md
@@ -64,7 +64,11 @@ Instead, commits such as "git init" or "npx create-solana-dapp@latest" to produc
 
 3. DevPie is built for and targeted at a team of software developers and engineers for their contributions (and possibly Project Management if GitHub's Projects and boards are utilized for project management tasks (A more feature-rich PM platform is likely required here (jira, kanban, tools etc.))). However, this leave out the UI/Art & Design/Legal/PR/Advertising/PM/Executive teams (if they exist in your organization), mostly if not entirely unrepresented. Therefore, it is likely that a separate, tangential equity deal would need to be reached by the organization as a whole, where allocations for each of the afformentioned teams have been determined, and the outcome of the DevPie algorithm determines the developer equity as a smaller part of the enitre pie.
 
-For instance, an organization may determine that 50% of the overall pie goes to the developer team, and the DevPie algorithm then determines how that 50% (of the grand total), is allocated, but the other sectors/teams of the business/organization have their own base allocations that collectively equal the other 50% of the overall pie.
+For instance, artwork committed to a repository may show as only +1 line or +1 file committed, and may be incredibly valuable to the project, but not adequately represented by the aglorithm. Outside considerations for this form of contribution and resulting equity will be needed by the wider organization/team.
+
+An organization may determine that 50% of the overall pie goes to the developer team, and the DevPie algorithm then determines how that 50% (of the grand total), is allocated, but the other sectors/teams of the business/organization have their own base allocations that collectively equal the other 50% of the overall pie.
+
+4. The /commits endpoint does not adequately show all contributions, contributors, nor activity to a repository. If just the /commits endpoint is considered, then some people will be left out of the final pie. The /contributors and /activity endpoints and their data should be considered as well.
 
 ---
 

--- a/devpie/README.md
+++ b/devpie/README.md
@@ -1,0 +1,81 @@
+# DevPie Equity Calculation Script
+
+This script allows users to interact with the GitHub API to retrieve information about a repository's code commits, and to calculate an equity or revenue split based on that history.
+
+## Current Algorithm
+
+Author:
+- 100 points awarded to the author for a commit.
+- 25 points for every line of code added.
+- 50 points for every line of code deleted.
+
+Committer:
+- 100 points awarded to the committer for a commit.
+- 25 points for every line of code added.
+- 50 points for every line of code deleted.
+
+## Prerequisites
+
+- Python 3.x
+- A GitHub account
+
+## Setting up the GitHub API Key
+
+1. Login to the gh cli locally, you will need your github oauth_token in your ~/.config/gh/hosts.yml file.
+
+Follow this if you need help: https://docs.github.com/en/github-cli/github-cli/quickstart
+
+## Steps to run:
+
+1. Change the "owner" and "repo" values to whatever repository you are looking to parse in the query_commits.py script.
+
+2. Run the query_commits.py script. 
+
+3. Run the parse_commits_csv.py script. (A file for all "*_commits.csv" files in your local directory will be parsed/created)
+
+4. View your *_distribution.png for your repo
+
+---
+
+NOTES: 
+
+1. The first version of the equity algorithm only takes into acccount the /commits endpoint for a repository. Future versions will take into consideration the /contributors and /activity endpoints to create a better picture of all the contributions to a repository, and not just its commits (which can sometimes miss other contributions).
+
+2. GitHub as an author or committer (such as when an automated workflow performs some action/commit), are excluded from the equity calculation.
+
+3. This project assumes, and requires a team of honorable, trustworthy, upstanding developers who are dedicated to producing something of value and doing so with integrity and strength of moral character. 
+
+It is possible to act unscrupulously and attempt to gain more equity than you are rightly owed. If this is the case, then perhaps you are not a person to be admitted into the project for equity consideration. If their exist multiple people who attempt to game the final equity calculation for their own benefit(s), then perhaps it is not a team worth being a member of. 
+
+There is no guarantee against bad actors, and there never will be. The importance of the humans involved matters.
+
+It does not pay to attempt to rig the system in your favor, but the room to-do-so therefore necessitates rigorous, thorough, and continued participation and vigilance from its members; in order to protect their own equity stake, and ensure fair distribution amongst the team in is entirety.
+
+--- 
+
+## Future Considerations to the Equity Algorithm
+
+Scaffolding, and boilerplate code:
+1. Initialization of front-end boilerplate can add 10,000+ lines of code (easily), with a signle CLI command. This type of contribution should not have a line-count multiplier added to it, and instead should be regarded as a lesser, lone commit, where the points for the commit are 10 (normal is 100) for the author and 10 for the committer. If these boilerplate or scaffold commits are allowed to be counted as normal they would severely alter the eventual pie in favor of the lucky author.
+
+Instead, commits such as "git init" or "npx create-solana-dapp@latest" to produce front end boilerplate should be their OWN COMMIT, with no other alterations or additions from the developer. These commits should be titled (or within the PR/commit message) with the words [BOILERPLATE, SCAFFOLDING, SCAFFOLD, or SCAFF]. The parser script will then know to treat these commits as separate, giving then a nominal point value. Again, these type of boilerplate commits should be PR'd/committed separately, with no further alterations, in order to not alter the outcome of the final pie.
+
+2. The addition of certain other types of files, such as readme files, config files, addition of new packages, etc., should possibly be treated differently as well, in order to not skew the addition of boilerplate (or non-CORE code). Likewise, perhaps core developer additions in the form of .rs, .py, .js, or other files should perhaps be weighted more heavily by the algorithm.
+
+3. DevPie is built for and targeted at a team of software developers and engineers for their contributions (and possibly Project Management if GitHub's Projects and boards are utilized for project management tasks (A more feature-rich PM platform is likely required here (jira, kanban, tools etc.))). However, this leave out the UI/Art & Design/Legal/PR/Advertising/PM/Executive teams (if they exist in your organization), mostly if not entirely unrepresented. Therefore, it is likely that a separate, tangential equity deal would need to be reached by the organization as a whole, where allocations for each of the afformentioned teams have been determined, and the outcome of the DevPie algorithm determines the developer equity as a smaller part of the enitre pie.
+
+For instance, an organization may determine that 50% of the overall pie goes to the developer team, and the DevPie algorithm then determines how that 50% (of the grand total), is allocated, but the other sectors/teams of the business/organization have their own base allocations that collectively equal the other 50% of the overall pie.
+
+---
+
+## Commit Rules
+
+In general, to ensure the integrity of the pie, stricter rules and procedures will need to be set and adhered-to by the team. Blind merging into main is not recommended, and manual review of code commits by the project's members/maintainers is necessary to ensure a quality codebase, and fair equity.
+
+1. Teams should institute mandatory branch protection rules, and PR commit/reviewer rules, where > 1 reviewer is required, and the author may not self-review their own PR's.
+
+2. All PR's should allow maintainer edits during reviews. (Keep the box checked)
+
+3. All boilerplate code (ANY CODE THAT YOU ADD BUT DIDN'T ACTUALLY WRITE), should be committed as its OWN PR, with NO ADDITIONAL CHANGES from the authoring developer. This includes things such as "git init" or addition of a front-end boilerplate framework, addition of packages and dependencies (this may be handled differently in the future by the algorithm if possible to avoid unnecessary headaches for developers committing such files), etc..
+
+4. Other commit rules intended to protect the integrity of the project and the final pie will be added here for consideration as they become apparently necessary.

--- a/devpie/parse_commits_csv.py
+++ b/devpie/parse_commits_csv.py
@@ -1,0 +1,66 @@
+import csv
+import matplotlib.pyplot as plt
+from typing import Dict, Set
+import glob
+import os
+
+# Function to process a single CSV file and generate a distribution plot
+def process_csv(file_path: str):
+    # Initialize dictionaries to store points and user ID to name mapping
+    points = {}
+    user_id_to_names: Dict[str, Set[str]] = {}
+
+    # Read the CSV file
+    with open(file_path, mode='r') as file:
+        reader = csv.DictReader(file)
+        for row in reader:
+            author_id = row['Author ID']
+            author_name = row['Author']
+            committer_id = row['Committer ID']
+            committer_name = row['Committer']
+            lines_added = int(row['Lines Added'])
+            lines_deleted = int(row['Lines Deleted'])
+
+            # Update the user ID to names mapping
+            if author_id not in user_id_to_names:
+                user_id_to_names[author_id] = set()
+            user_id_to_names[author_id].add(author_name)
+
+            if committer_id not in user_id_to_names:
+                user_id_to_names[committer_id] = set()
+            user_id_to_names[committer_id].add(committer_name)
+
+            # Calculate points for the author
+            if author_id not in points:
+                points[author_id] = 0
+            points[author_id] += 100 + (25 * lines_added)+ (50 * lines_deleted)
+
+            # Exclude GitHub commits from calculations
+            if "GitHub" in committer_name:
+                continue
+
+            # Calculate points for the committer, excluding GitHub
+            if committer_id not in points:
+                points[committer_id] = 0
+            points[committer_id] += 100 + (25 * lines_added) + (50 * lines_deleted)
+
+    # Generate the distribution pie chart
+    labels = [f"{', '.join(user_id_to_names[user_id])} ({user_id})" for user_id in points.keys()]
+    scores = list(points.values())
+
+    plt.figure(figsize=(10, 5))
+    plt.pie(scores, labels=labels, autopct='%1.1f%%', startangle=140)
+    plt.title('Contribution Points Distribution', loc='left')
+    plt.axis('equal')  # Equal aspect ratio ensures that pie is drawn as a circle.
+
+    # Save the plot as a PNG file
+    output_file = os.path.splitext(file_path)[0] + '_distribution.png'
+    plt.savefig(output_file)
+    plt.close()
+
+# Find all *_commits.csv files
+csv_files = glob.glob('*_commits.csv')
+
+# Process each CSV file
+for csv_file in csv_files:
+    process_csv(csv_file)

--- a/devpie/query_commits.py
+++ b/devpie/query_commits.py
@@ -1,0 +1,66 @@
+import requests # type: ignore
+import csv
+import yaml # type: ignore
+import os
+
+# Path to the GitHub CLI configuration file
+config_path = os.path.expanduser('~/.config/gh/hosts.yml')
+
+# Read the GitHub API token from the configuration file
+with open(config_path, 'r') as file:
+    config = yaml.safe_load(file)
+    token = config['github.com']['oauth_token']
+
+# GitHub repository details
+owner = 'Web3-Builders-Alliance'
+repo = 'soda'
+commits_url = f'https://api.github.com/repos/{owner}/{repo}/commits'
+
+headers = {
+    'Authorization': f'token {token}'
+}
+
+# Make a request to the GitHub API to get commit data
+response = requests.get(commits_url, headers=headers)
+commits = response.json()
+
+# Format the CSV file name with the owner and repo values
+csv_file_name = f'{owner}_{repo}_commits.csv'
+
+# Open a CSV file to write the data
+with open(csv_file_name, mode='w', newline='') as file:
+    writer = csv.writer(file)
+    # Write the header row
+    writer.writerow(["SHA", "Author", "Author ID", "Committer", "Committer ID", "Date", "Message", "Lines Added", "Lines Deleted", "Verified"])
+
+    # Write commit data
+    for commit in commits:
+        sha = commit['sha']
+        author = commit['commit']['author']['name']
+        author_id = commit['author']['id'] if commit['author'] else None
+        committer = commit['commit']['committer']['name']
+        committer_id = commit['committer']['id'] if commit['committer'] else None
+        date = commit['commit']['author']['date']
+        message = commit['commit']['message']
+
+        # Fetch detailed commit information
+        commit_url = f'https://api.github.com/repos/{owner}/{repo}/commits/{sha}'
+        commit_response = requests.get(commit_url, headers=headers)
+        commit_details = commit_response.json()
+
+        # Extract lines added and deleted
+        stats = commit_details.get('stats', {})
+        lines_added = stats.get('additions', 0)
+        lines_deleted = stats.get('deletions', 0)
+
+        # Extract verification details
+        verification = commit_details['commit'].get('verification', {})
+        verified = verification.get('verified', False)
+
+        # Skip empty lines
+        if not sha.strip() or not author.strip() or not committer.strip() or not date.strip() or not message.strip():
+            continue
+
+        writer.writerow([sha, author, author_id, committer, committer_id, date, message, lines_added, lines_deleted, verified])
+
+print("Commit data has been written to commits.csv")

--- a/devpie/query_contributors.py
+++ b/devpie/query_contributors.py
@@ -1,0 +1,43 @@
+import requests # type: ignore
+import csv
+import yaml # type: ignore
+import os
+
+# Path to the GitHub CLI configuration file
+config_path = os.path.expanduser('~/.config/gh/hosts.yml')
+
+# Read the GitHub API token from the configuration file
+with open(config_path, 'r') as file:
+    config = yaml.safe_load(file)
+    token = config['github.com']['oauth_token']
+
+# GitHub repository details
+owner = 'Web3-Builders-Alliance'
+repo = 'soda'
+contributors_url = f'https://api.github.com/repos/{owner}/{repo}/contributors'
+
+headers = {
+    'Authorization': f'token {token}'
+}
+
+# Make a request to the GitHub API to get contributors data
+response = requests.get(contributors_url, headers=headers)
+contributors = response.json()
+
+# Format the CSV file name with the owner and repo values
+csv_file_name = f'{owner}_{repo}_contributors.csv'
+
+# Open a CSV file to write the data
+with open(csv_file_name, mode='w', newline='') as file:
+    writer = csv.writer(file)
+    # Write the header row
+    writer.writerow(["Login", "ID", "Type", "Contributions"])
+
+    # Write contributor data
+    for contributor in contributors:
+        login = contributor['login']
+        id = contributor['id']
+        type = contributor['type']
+        contributions = contributor['contributions']
+
+        writer.writerow([login, id, type, contributions])


### PR DESCRIPTION
These are the v0 "preliminary" python scripts for calculating equity from only the /commits endpoint through the github api.

A secondary contributors script is there, but its outputs are not yet taken into account for the equity calculation; currently only commits are part of the algorithm.

In future versions, the /contributors and /activity endpoints and their respective data will likely be taken into account as well.